### PR TITLE
Fix header menu moving on menu hover

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -282,6 +282,7 @@ export default function Header() {
                   anchorEl={state.anchorEl}
                   getContentAnchorEl={null}
                   keepMounted
+                  disableScrollLock
                   open={state[label] ? state[label] : false}
                   onClose={handleClose.bind(this, label)}
                   id={`idolfest-menu-${label}`}


### PR DESCRIPTION
https://trello.com/c/gRCZWObf/12-fix-top-nav-dropdown-glitchiness

The header uses Material-UI's Menu, which by default adds some scroll locking behavior, and this adds some padding to the body, which causes the header to shift. https://stackoverflow.com/questions/60682426/material-ui-adds-padding-to-the-body-tag-when-a-dialog-is-opened

This disables the scroll lock on those menus.