### PR TITLE
Close down home and registration pages

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -16,10 +16,12 @@ import { Link } from 'gatsby'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const headersData = [
+  /*
   {
     label: "Register",
     href: "/register",
   },
+  */
   {
     label: "Hotel",
     href: "/hotel",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,34 +3,20 @@ import Hero from '@components/hero'
 import Layout from '@components/layout'
 import Seo from '@components/seo'
 import PageContent from '@components/PageContent'
-import PageHeader from '@components/PageHeader'
 import NewsletterSignup from '@components/NewsletterSignup'
-import BlogPosts from '@components/BlogPosts'
-import { Link } from 'gatsby'
 
 const IndexPage = () => {
   return (
     <Layout>
       <Seo title="Home" />
 
-      <Hero 
-        header="Announcing NW IdolFest!"
-      />
-      
-      <PageHeader 
-        title="Welcome to Northwest IdolFest!" 
-      />
+      <Hero header="Thank you for attending NW IdolFest 2021!" />
 
       <PageContent>
-        <p>Northwest Idol Festival is a two day event featuring idols, anisong, and everything in between. Join us in Seattle on November 13-14, 2021 for an exciting weekend of guests, concerts, panels, cosplay, and more. Get ready for a whole new idol experience!</p>
-        <p>Ready to find out more? <Link to="/hotel">Book your hotel room</Link> and <Link to="register">buy your badge</Link> today!</p>
-        
-        <div style={{ paddingTop: '1em' }} />
-        
-        <BlogPosts />
-        
-        <h2 style={{ paddingTop: '1em' }}>Newsletter</h2>
-        <p>Sign up for our email list below to get the scoop on guest announcements, giveaways, and more!</p>
+        <p>
+          Thank you for attending Northwest Idol Festival 2021! Sign up for our
+          email list below to get notified when our next convention will be!
+        </p>
         <NewsletterSignup />
       </PageContent>
     </Layout>

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -19,6 +19,8 @@ import {
 import { styled } from '@material-ui/styles'
 import { navigate, Link } from 'gatsby'
 import RegistrationTier from '@components/registrationTier'
+import Hero from "@components/hero"
+import NewsletterSignup from "@components/NewsletterSignup"
 
 let lambdaUrl
 
@@ -473,4 +475,23 @@ const RegisterPage = () => {
   </Layout>
 )}
 
-export default RegisterPage
+const ClosedRegisterPage = () => {
+  return (
+    <Layout>
+      <Seo title="Register" />
+
+      <Hero header="Thank you for attending NW IdolFest 2021!" />
+
+      <PageContent>
+        <p>
+          Registration is closed because Northwest Idol Festival 2021 is now
+          over. Sign up for our email list below to get notified when our next
+          convention will be!
+        </p>
+        <NewsletterSignup />
+      </PageContent>
+    </Layout>
+  )
+}
+
+export default ClosedRegisterPage


### PR DESCRIPTION
Removes 2021 content from the home page and registration page, directs people to the newsletter on both, and removes the registration link from the header.

Home page:

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/28552/141674046-d25ae86d-b82a-4411-aff8-e792a506f8b9.png">

Registration page:

<img width="1561" alt="image" src="https://user-images.githubusercontent.com/28552/141674099-a5ff667c-9828-414e-9dda-3638cf8da7bd.png">
