### PR TITLE
Disable registration

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -16,10 +16,12 @@ import { Link } from 'gatsby'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const headersData = [
+  /*
   {
     label: "Register",
     href: "/register",
   },
+  */
   {
     label: "Hotel",
     href: "/hotel",

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -19,6 +19,8 @@ import {
 import { styled } from '@material-ui/styles'
 import { navigate, Link } from 'gatsby'
 import RegistrationTier from '@components/registrationTier'
+import Hero from '@components/hero'
+import NewsletterSignup from '@components/NewsletterSignup'
 
 let lambdaUrl
 
@@ -473,4 +475,23 @@ const RegisterPage = () => {
   </Layout>
 )}
 
-export default RegisterPage
+const ClosedRegisterPage = () => {
+  return (
+    <Layout>
+      <Seo title="Register" />
+
+      <Hero header="Thank you for attending NW IdolFest 2021!" />
+
+      <PageContent>
+        <p>
+          Registration is closed because Northwest Idol Festival 2021 is now
+          over. Sign up for our email list below to get notified when our next
+          convention will be!
+        </p>
+        <NewsletterSignup />
+      </PageContent>
+    </Layout>
+  )
+}
+
+export default ClosedRegisterPage


### PR DESCRIPTION
Removes the Register tab from the header, and removes the form from `/register` if anyone ends up there.

<img width="1545" alt="image" src="https://user-images.githubusercontent.com/28552/141694133-5bf3c596-43b9-41eb-b04d-e8717dd66fee.png">
