### PR TITLE
Remove content from home page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,10 +3,7 @@ import Hero from '@components/hero'
 import Layout from '@components/layout'
 import Seo from '@components/seo'
 import PageContent from '@components/PageContent'
-import PageHeader from '@components/PageHeader'
 import NewsletterSignup from '@components/NewsletterSignup'
-import BlogPosts from '@components/BlogPosts'
-import { Link } from 'gatsby'
 
 const IndexPage = () => {
   return (
@@ -14,23 +11,11 @@ const IndexPage = () => {
       <Seo title="Home" />
 
       <Hero 
-        header="Announcing NW IdolFest!"
+        header="Thank you for attending NW IdolFest 2021!"
       />
       
-      <PageHeader 
-        title="Welcome to Northwest IdolFest!" 
-      />
-
       <PageContent>
-        <p>Northwest Idol Festival is a two day event featuring idols, anisong, and everything in between. Join us in Seattle on November 13-14, 2021 for an exciting weekend of guests, concerts, panels, cosplay, and more. Get ready for a whole new idol experience!</p>
-        <p>Ready to find out more? <Link to="/hotel">Book your hotel room</Link> and <Link to="register">buy your badge</Link> today!</p>
-        
-        <div style={{ paddingTop: '1em' }} />
-        
-        <BlogPosts />
-        
-        <h2 style={{ paddingTop: '1em' }}>Newsletter</h2>
-        <p>Sign up for our email list below to get the scoop on guest announcements, giveaways, and more!</p>
+        <p>Thank you for attending Northwest Idol Festival 2021! Sign up for our email list below to get notified when our next convention will be!</p>
         <NewsletterSignup />
       </PageContent>
     </Layout>


### PR DESCRIPTION
Removes the content from the home page and redirects to sign up for the newsletter.

Note: When #8 is merged this will pick up the removal of the Register link from the header.

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/28552/141694503-79784178-9556-468b-add6-3f3158d60733.png">
